### PR TITLE
Fix map serialization and add serialization tests

### DIFF
--- a/.cljfmt
+++ b/.cljfmt
@@ -4,4 +4,5 @@
  :padding-lines 2
  :max-consecutive-blank-lines 3
  :single-import-break-width 80
- :indents {with-context [[:block 1]]}}
+ :indents {with-context [[:block 1]]
+           for-all [[:block 1]]}}

--- a/project.clj
+++ b/project.clj
@@ -17,6 +17,11 @@
    [amperity/sparkplug-sql "0.1.0-SNAPSHOT"]
    [amperity/sparkplug-ml "0.1.0-SNAPSHOT"]]
 
+  :profiles
+  {:dev
+   {:dependencies
+    [[org.clojure/test.check "0.10.0"]]}}
+
   :monolith
   {:project-dirs ["sparkplug-core"
                   "sparkplug-sql"

--- a/sparkplug-core/project.clj
+++ b/sparkplug-core/project.clj
@@ -30,16 +30,15 @@
    [:base :system :user :provided :spark-2.4 :dev]
 
    :dev
-   {:jvm-opts ["-server" "-Xmx2g"]}
+   {:jvm-opts ["-server" "-Xmx2g"]
+    :dependencies
+    [[org.clojure/test.check "0.10.0"]]}
 
    :repl
    {:source-paths ["dev"]
     :dependencies
     [[org.clojure/tools.namespace "0.2.11"]]}
 
-   :test
-   {:dependencies
-    [[org.clojure/test.check "0.10.0"]]}
 
    :spark-2.2
    ^{:pom-scope :provided}

--- a/sparkplug-core/project.clj
+++ b/sparkplug-core/project.clj
@@ -37,6 +37,10 @@
     :dependencies
     [[org.clojure/tools.namespace "0.2.11"]]}
 
+   :test
+   {:dependencies
+    [[org.clojure/test.check "0.10.0"]]}
+
    :spark-2.2
    ^{:pom-scope :provided}
    {:dependencies

--- a/sparkplug-core/project.clj
+++ b/sparkplug-core/project.clj
@@ -39,7 +39,6 @@
     :dependencies
     [[org.clojure/tools.namespace "0.2.11"]]}
 
-
    :spark-2.2
    ^{:pom-scope :provided}
    {:dependencies

--- a/sparkplug-core/src/clojure/sparkplug/kryo.clj
+++ b/sparkplug-core/src/clojure/sparkplug/kryo.clj
@@ -523,8 +523,9 @@
   "Write a sequence of key/value pairs to the Kryo output."
   [^Kryo kryo ^Output output coll]
   (.writeVarInt output (count coll) true)
-  (doseq [x coll]
-    (.writeClassAndObject kryo output x)))
+  (doseq [[k v] coll]
+    (.writeClassAndObject kryo output k)
+    (.writeClassAndObject kryo output v)))
 
 
 (defn- read-kvs

--- a/sparkplug-core/test/sparkplug/kryo_test.clj
+++ b/sparkplug-core/test/sparkplug/kryo_test.clj
@@ -1,10 +1,44 @@
 (ns sparkplug.kryo-test
   (:require
-    [clojure.test :refer [deftest testing is]]
-    [sparkplug.kryo :as kryo]))
+    [clojure.test :refer [are deftest testing is]]
+    [sparkplug.kryo :as kryo])
+  (:import
+    com.esotericsoftware.kryo.Kryo
+    (com.esotericsoftware.kryo.io
+      Input
+      Output)))
 
 
 (deftest classpath-search
   (let [registries (kryo/classpath-registries)]
     (is (sequential? registries))
     (is (<= 2 (count registries)))))
+
+
+(defn- serialize
+  ^bytes [^Kryo kryo obj]
+  (let [output (Output. 4096 -1)]
+    (.writeClassAndObject kryo output obj)
+    (.flush output)
+    (.getBuffer output)))
+
+
+(defn- deserialize
+  [^Kryo kryo ^bytes data]
+  (let [input (Input. data)]
+    (.readClassAndObject kryo input)))
+
+
+(deftest clojure-serialization
+  (are [x] (let [kryo (kryo/initialize)]
+             (= x (->> x (serialize kryo) (deserialize kryo))))
+
+    5
+    5/7
+    'foo
+    "foo"
+    :foo
+    [1]
+    #{"a"}
+    {"a" "b"}
+    {:foo "bar"}))

--- a/sparkplug-core/test/sparkplug/kryo_test.clj
+++ b/sparkplug-core/test/sparkplug/kryo_test.clj
@@ -26,5 +26,4 @@
   {:num-tests 1000
    :max-size 20}
   (prop/for-all [x gen/any-equatable]
-    (println (pr-str x))
     (is (= x (->> x (kryo/encode kryo) (kryo/decode kryo))))))

--- a/sparkplug-core/test/sparkplug/kryo_test.clj
+++ b/sparkplug-core/test/sparkplug/kryo_test.clj
@@ -19,20 +19,12 @@
     (is (<= 2 (count registries)))))
 
 
-(defn- replace-incomparable-types
-  "Replace regex patterns and NaN with keywords because they are not
-  comparable by value."
-  [x]
-  (walk/postwalk
-    #(cond (and (number? %) (Double/isNaN %)) :NaN
-           (instance? java.util.regex.Pattern %) :regex
-           :else %)
-    x))
-
-
 (def kryo (kryo/initialize))
 
 
-(defspec clojure-data-roundtrip 1000
-  (prop/for-all [x (gen/fmap replace-incomparable-types gen/any)]
+(defspec clojure-data-roundtrip
+  {:num-tests 1000
+   :max-size 20}
+  (prop/for-all [x gen/any-equatable]
+    (println (pr-str x))
     (is (= x (->> x (kryo/encode kryo) (kryo/decode kryo))))))


### PR DESCRIPTION
Nice library! I played with it a bit and found that map serialization wasn't working. Turns out it was writing each map entry as a single object but reading two objects at a time into map entries. For example, `{:a "b"}` would deserialize as `{[:a "b"] nil}`, if running in a local Spark context, and if running in cluster would result in a Kryo buffer underflow error. Here's a fix and a generative test for roundtripping Clojure data. Good news, looks like all the other serializers work well! 🙂 