### PR TITLE
Honor preserve-partitioning in map-partitions

### DIFF
--- a/sparkplug-core/src/clojure/sparkplug/core.clj
+++ b/sparkplug-core/src/clojure/sparkplug/core.clj
@@ -78,9 +78,12 @@
   ([f ^JavaRDD rdd]
    (map-partitions f false rdd))
   ^JavaRDD
-  ([f preserve-partitioni ^JavaRDD rdd]
+  ([f preserve-partitioning? ^JavaRDD rdd]
    (rdd/set-callsite-name
-     (.mapPartitions rdd (f/flat-map-fn f))
+     (.mapPartitions
+       rdd
+       (f/flat-map-fn f)
+       (boolean preserve-partitioning?))
      (rdd/fn-name f))))
 
 


### PR DESCRIPTION
We were passing in the flag for `preserve-partitioning?` but not actually using in the `mapPartitions` call. 