### PR TITLE
Adjust type hints to allow working with pair RDDs

### DIFF
--- a/sparkplug-core/src/clojure/sparkplug/core.clj
+++ b/sparkplug-core/src/clojure/sparkplug/core.clj
@@ -268,6 +268,7 @@
     (.cartesian rdd1 rdd2)))
 
 
+;; Type hints are omitted because `union` is not included in JavaRDDLike.
 (defn union
   "Construct a union of the elements in the provided RDDs. Any identical
   elements will appear multiple times."
@@ -284,6 +285,7 @@
              ^java.util.List (list* rdd2 rdds)))))
 
 
+;; Type hints are omitted because `intersecton` is not included in JavaRDDLike.
 (defn intersection
   "Construct an RDD representing the intersection of elements which are in both
   RDDs."

--- a/sparkplug-core/src/clojure/sparkplug/core.clj
+++ b/sparkplug-core/src/clojure/sparkplug/core.clj
@@ -42,7 +42,7 @@
 
 (defn filter
   "Filter the elements of `rdd` to the ones which satisfy the predicate `f`."
-  ^JavaRDD
+  ^JavaRDDLike
   [f ^JavaRDDLike rdd]
   (rdd/set-callsite-name
     (.filter rdd (f/fn1 (comp boolean f)))
@@ -52,8 +52,8 @@
 (defn map
   "Map the function `f` over each element of `rdd`. Returns a new RDD
   representing the transformed elements."
-  ^JavaRDD
-  [f ^JavaRDD rdd]
+  ^JavaRDDLike
+  [f ^JavaRDDLike rdd]
   (rdd/set-callsite-name
     (.map rdd (f/fn1 f))
     (rdd/fn-name f)))
@@ -75,10 +75,10 @@
   results. Returns an RDD representing the concatenation of all the partition
   results. The function will be called with an iterator of the elements of each
   partition."
-  ^JavaRDD
+  ^JavaRDDLike
   ([f ^JavaRDDLike rdd]
    (map-partitions f false rdd))
-  ^JavaRDD
+  ^JavaRDDLike
   ([f preserve-partitioning? ^JavaRDDLike rdd]
    (rdd/set-callsite-name
      (.mapPartitions
@@ -104,11 +104,11 @@
   "Construct an RDD containing only a single copy of each distinct element in
   `rdd`. Optionally accepts a number of partitions to size the resulting RDD
   with."
-  ^JavaRDD
-  ([^JavaRDD rdd]
+  ^JavaRDDLike
+  ([^JavaRDDLike rdd]
    (rdd/set-callsite-name
      (.distinct rdd)))
-  ([num-partitions ^JavaRDD rdd]
+  ([num-partitions ^JavaRDDLike rdd]
    (rdd/set-callsite-name
      (.distinct rdd (int num-partitions))
      (int num-partitions))))
@@ -118,19 +118,19 @@
   "Generate a randomly sampled subset of `rdd` with roughly `fraction` of the
   original elements. Callers can optionally select whether the sample happens
   with replacement, and a random seed to control the sample."
-  ^JavaRDD
-  ([fraction ^JavaRDD rdd]
+  ^JavaRDDLike
+  ([fraction ^JavaRDDLike rdd]
    (rdd/set-callsite-name
      (.sample rdd true (double fraction))
      (double fraction)))
-  ^JavaRDD
-  ([fraction replacement? ^JavaRDD rdd]
+  ^JavaRDDLike
+  ([fraction replacement? ^JavaRDDLike rdd]
    (rdd/set-callsite-name
      (.sample rdd (boolean replacement?) (double fraction))
      (double fraction)
      (boolean replacement?)))
-  ^JavaRDD
-  ([fraction replacement? seed ^JavaRDD rdd]
+  ^JavaRDDLike
+  ([fraction replacement? seed ^JavaRDDLike rdd]
    (rdd/set-callsite-name
      (.sample rdd (boolean replacement?) (double fraction) (long seed))
      (double fraction)
@@ -160,6 +160,7 @@
 (defn key-by
   "Creates pairs from the elements in `rdd` by using `f` to compute a key for
   each value."
+  ^JavaPairRDD
   [f ^JavaRDDLike rdd]
   (rdd/set-callsite-name
     (.mapToPair rdd (f/pair-fn (juxt f identity)))
@@ -293,8 +294,8 @@
 
 (defn subtract
   "Remove all elements from `rdd1` that are present in `rdd2`."
-  ^JavaRDD
-  [^JavaRDD rdd1 ^JavaRDD rdd2]
+  ^JavaRDDLike
+  [^JavaRDDLike rdd1 ^JavaRDDLike rdd2]
   (rdd/set-callsite-name
     (.subtract rdd1 rdd2)))
 

--- a/sparkplug-core/src/clojure/sparkplug/core.clj
+++ b/sparkplug-core/src/clojure/sparkplug/core.clj
@@ -738,7 +738,7 @@
 
   This is an action that causes computation."
   [^JavaPairRDD rdd]
-  (into {} (.countByKey rdd)))
+  (c/into {} (.countByKey rdd)))
 
 
 (defn count-by-value
@@ -747,4 +747,4 @@
 
   This is an action that causes computation."
   [^JavaRDDLike rdd]
-  (into {} (.countByValue rdd)))
+  (c/into {} (.countByValue rdd)))

--- a/sparkplug-core/src/clojure/sparkplug/rdd.clj
+++ b/sparkplug-core/src/clojure/sparkplug/rdd.clj
@@ -23,12 +23,14 @@
 
 ;; ## Naming Functions
 
+;; Type hints are omitted because `name` is not included in JavaRDDLike.
 (defn name
   "Return the current name for `rdd`."
   [rdd]
   (.name rdd))
 
 
+;; Type hints are omitted because `setName` is not included in JavaRDDLike.
 (defn set-name
   "Set the name of `rdd` to `name-str`."
   ^JavaRDDLike
@@ -222,6 +224,7 @@
     (.getName (class partitioner))))
 
 
+;; Type hints are omitted because `repartition` is not included in JavaRDDLike.
 (defn repartition
   "Returns a new `rdd` with exactly `n` partitions.
 
@@ -230,13 +233,14 @@
 
   If you are decreasing the number of partitions in this RDD, consider using
   `coalesce`, which can avoid performing a shuffle."
-  ^JavaRDD
-  [n ^JavaRDD rdd]
+  ^JavaRDDLike
+  [n rdd]
   (set-callsite-name
     (.repartition rdd (int n))
     (int n)))
 
 
+;; Type hints are omitted because `coalesce` is not included in JavaRDDLike.
 (defn coalesce
   "Decrease the number of partitions in `rdd` to `n`. Useful for running
   operations more efficiently after filtering down a large dataset."
@@ -279,6 +283,8 @@
         level)))
 
 
+;; Type hints are omitted because `cache` and `persist` are not included in
+;; JavaRDDLike.
 (defn cache!
   "Sets the storage level of `rdd` to persist its values across operations
   after the first time it is computed. By default, this uses the `:memory-only`
@@ -293,6 +299,7 @@
    (.persist rdd (get storage-levels level))))
 
 
+;; Type hints are omitted because `unpersist` is not included in JavaRDDLike.
 (defn uncache!
   "Mark `rdd` as non-persistent, and remove all blocks for it from memory and
   disk. Blocks until all data has been removed unless `blocking?` is provided

--- a/sparkplug-core/src/clojure/sparkplug/rdd.clj
+++ b/sparkplug-core/src/clojure/sparkplug/rdd.clj
@@ -16,6 +16,7 @@
     (org.apache.spark.api.java
       JavaPairRDD
       JavaRDD
+      JavaRDDLike
       JavaSparkContext
       StorageLevels)))
 
@@ -24,14 +25,14 @@
 
 (defn name
   "Return the current name for `rdd`."
-  [^JavaRDD rdd]
+  [rdd]
   (.name rdd))
 
 
 (defn set-name
   "Set the name of `rdd` to `name-str`."
-  ^JavaRDD
-  [name-str ^JavaRDD rdd]
+  ^JavaRDDLike
+  [name-str rdd]
   (.setName rdd name-str))
 
 
@@ -176,7 +177,7 @@
   directory `path` in the local filesystem, HDFS or any other Hadoop-supported
   file system. Spark will call toString on each element to convert it to a line
   of text in the file."
-  [path ^JavaRDD rdd]
+  [path ^JavaRDDLike rdd]
   (.saveAsTextFile rdd (str path)))
 
 
@@ -201,14 +202,14 @@
 
 (defn partitions
   "Return a vector of the partitions in `rdd`."
-  [^JavaRDD rdd]
+  [^JavaRDDLike rdd]
   (into [] (.partitions (.rdd rdd))))
 
 
 (defn partitioner
   "Return the partitioner associated with `rdd`, or nil if there is no custom
   partitioner."
-  [^JavaPairRDD rdd]
+  [^JavaRDDLike rdd]
   (scala/resolve-option
     (.partitioner (.rdd rdd))))
 
@@ -239,10 +240,9 @@
 (defn coalesce
   "Decrease the number of partitions in `rdd` to `n`. Useful for running
   operations more efficiently after filtering down a large dataset."
-  ^JavaRDD
-  ([num-partitions ^JavaRDD rdd]
+  ([num-partitions rdd]
    (coalesce num-partitions false rdd))
-  ([num-partitions shuffle? ^JavaRDD rdd]
+  ([num-partitions shuffle? rdd]
    (set-callsite-name
      (.coalesce rdd (int num-partitions) (boolean shuffle?))
      (int num-partitions)
@@ -286,11 +286,9 @@
 
   This can only be used to assign a new storage level if the RDD does not have
   a storage level set already."
-  ^JavaRDD
-  ([^JavaRDD rdd]
+  ([rdd]
    (.cache rdd))
-  ^JavaRDD
-  ([level ^JavaRDD rdd]
+  ([level rdd]
    {:pre [(contains? storage-levels level)]}
    (.persist rdd (get storage-levels level))))
 
@@ -299,17 +297,15 @@
   "Mark `rdd` as non-persistent, and remove all blocks for it from memory and
   disk. Blocks until all data has been removed unless `blocking?` is provided
   and false."
-  ^JavaRDD
-  ([^JavaRDD rdd]
+  ([rdd]
    (.unpersist rdd))
-  ^JavaRDD
-  ([blocking? ^JavaRDD rdd]
+  ([blocking? rdd]
    (.unpersist rdd (boolean blocking?))))
 
 
 (defn checkpointed?
   "True if `rdd` has been marked for checkpointing."
-  [^JavaRDD rdd]
+  [^JavaRDDLike rdd]
   (.isCheckpointed rdd))
 
 
@@ -321,5 +317,5 @@
   This function must be called before any job has been executed on this RDD. It
   is strongly recommended that this RDD is persisted in memory, otherwise
   saving it to a file will require recomputation."
-  [^JavaRDD rdd]
+  [^JavaRDDLike rdd]
   (.checkpoint rdd))


### PR DESCRIPTION
I have been working on migrating from sparkling to sparkplug in an existing Spark application that uses mostly transformations on pair RDDs. I found that many sparkplug functions, e.g. `sparkplug.core/filter`, were type hinted with JavaRDD, so they would throw ClassCastException when applied to pair RDDs.

As a silly example:
```clojure
user=> (context/with-context [sc local-conf]
         (->> (rdd/parallelize sc (range 10))
              (spark/key-by identity)
              (spark/filter #(even? (._1 %)))
              (spark/into [])))
Execution error (ClassCastException) at sparkplug.core/filter (core.clj:...).
org.apache.spark.api.java.JavaPairRDD cannot be cast to org.apache.spark.api.java.JavaRDD
```

Where possible, I changed the type hints to the JavaRDDLike interface, but unfortunately some methods (for example, `.setName`) are not part of this interface - they belong to the concrete JavaRDD, JavaPairRDD, etc. classes. In these cases I opted to omit the type hints because I don't think method calls on the RDD objects are performance-sensitive anyway.