### PR TITLE
Kryo registrator singleton

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   clojure:
     docker:
-      - image: circleci/clojure:lein-2.9.1
+      - image: circleci/clojure:openjdk-8-lein-2.9.1
     working_directory: ~/repo
 
 


### PR DESCRIPTION
## Description

This change modifies the Kryo configuration code a bit to cache the loaded configuration. The previous approach means that for _each_ Kryo instance in _every_ task, Spark was re-running the classpath-walking code to discover registry files. This is at best noisy and is pretty inefficient.

## Changes

- I removed the old `configure!` function and replaced it with `load-configuration` which walks the classpath once to produce a function which can be called on a Kryo instance to configure it.
- `ClassPathRegistrator` uses a singleton to hold the compiled function and reuse it for the lifetime of that `ClassLoader`.

## Testing

I verified using `sparkplug-repl` that the classpath is walked once and then each successive task does not re-load it.