### PR TITLE
Require the Clojure namespace upon deserializing a SerializableFn

### DIFF
--- a/sparkplug-core/src/java/sparkplug/function/SerializableFn.java
+++ b/sparkplug-core/src/java/sparkplug/function/SerializableFn.java
@@ -1,8 +1,14 @@
 package sparkplug.function;
 
 
+import clojure.lang.Compiler;
 import clojure.lang.IFn;
+import clojure.lang.RT;
+import clojure.lang.Symbol;
 
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
 
@@ -18,6 +24,24 @@ public abstract class SerializableFn implements Serializable {
      * Default empty constructor.
      */
     private SerializableFn() {
+    }
+
+
+    private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+        // Attempt to derive the needed Clojure namespace from the function's class name.
+        String namespace = Compiler.demunge(this.f.getClass().getName()).split("/")[0];
+        out.writeObject(namespace);
+        out.writeObject(this.f);
+    }
+
+
+    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+        String namespace = (String)in.readObject();
+        Symbol namespaceSym = Symbol.intern(namespace);
+        synchronized (RT.REQUIRE_LOCK) {
+            RT.var("clojure.core", "require").invoke(namespaceSym);
+        }
+        this.f = (IFn)in.readObject();
     }
 
 

--- a/sparkplug-core/src/java/sparkplug/function/SerializableFn.java
+++ b/sparkplug-core/src/java/sparkplug/function/SerializableFn.java
@@ -39,6 +39,7 @@ public abstract class SerializableFn implements Serializable {
     private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         String namespace = (String)in.readObject();
         Symbol namespaceSym = Symbol.intern(namespace);
+        // TODO: Try optimizing by doing an unsynchronized resolve first.
         synchronized (RT.REQUIRE_LOCK) {
             RT.var("clojure.core", "require").invoke(namespaceSym);
         }

--- a/sparkplug-core/src/java/sparkplug/function/SerializableFn.java
+++ b/sparkplug-core/src/java/sparkplug/function/SerializableFn.java
@@ -8,6 +8,7 @@ import clojure.lang.Symbol;
 
 import java.io.IOException;
 import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
@@ -27,7 +28,7 @@ public abstract class SerializableFn implements Serializable {
     }
 
 
-    private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+    private void writeObject(ObjectOutputStream out) throws IOException {
         // Attempt to derive the needed Clojure namespace from the function's class name.
         String namespace = Compiler.demunge(this.f.getClass().getName()).split("/")[0];
         out.writeObject(namespace);
@@ -35,7 +36,7 @@ public abstract class SerializableFn implements Serializable {
     }
 
 
-    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
         String namespace = (String)in.readObject();
         Symbol namespaceSym = Symbol.intern(namespace);
         synchronized (RT.REQUIRE_LOCK) {


### PR DESCRIPTION
Some experiments showed that passing a function that closed over any Var would result in attempting to use an unbound Var when an executor tried to execute the task. 

The root cause is that functions passed to Spark are not serialized using Kryo and the custom registrator. Functions are actually serialized using the regular Java Serializable interface. Hence, none of the logic in `sparkplug.kryo` to serialize and deserialize Vars applies to functions. (see https://issues.apache.org/jira/browse/SPARK-12414).

The proposed workaround (maybe solution?) here is to store the function's declaring namespace alongside the serialized function, and require that namespace when the function is deserialized.