### PR TITLE
Bring back code walking to determine set of namespaces to require

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/sparkplug "0.1.1-SNAPSHOT"
+(defproject amperity/sparkplug "0.1.2-SNAPSHOT"
   :description "Clojure API for Apache Spark"
   :url "https://github.com/amperity/sparkplug"
   :license {:name "Apache License 2.0"
@@ -13,9 +13,9 @@
 
   :dependencies
   [[org.clojure/clojure "1.10.1"]
-   [amperity/sparkplug-core "0.1.1-SNAPSHOT"]
-   [amperity/sparkplug-sql "0.1.1-SNAPSHOT"]
-   [amperity/sparkplug-ml "0.1.1-SNAPSHOT"]]
+   [amperity/sparkplug-core "0.1.2-SNAPSHOT"]
+   [amperity/sparkplug-sql "0.1.2-SNAPSHOT"]
+   [amperity/sparkplug-ml "0.1.2-SNAPSHOT"]]
 
   :profiles
   {:dev

--- a/sparkplug-core/project.clj
+++ b/sparkplug-core/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/sparkplug-core "0.1.1-SNAPSHOT"
+(defproject amperity/sparkplug-core "0.1.2-SNAPSHOT"
   :description "Clojure API for Apache Spark"
   :url "https://github.com/amperity/sparkplug"
   :scm {:dir ".."}

--- a/sparkplug-core/src/clojure/sparkplug/function.clj
+++ b/sparkplug-core/src/clojure/sparkplug/function.clj
@@ -1,6 +1,6 @@
 (ns sparkplug.function
   "This namespace generates function classes for various kinds of interop with
-  Spark and Scala. This namespace **must** be AOT compiled before using Spark."
+  Spark and Scala."
   (:import
     (java.lang.reflect
       Field

--- a/sparkplug-core/src/clojure/sparkplug/function.clj
+++ b/sparkplug-core/src/clojure/sparkplug/function.clj
@@ -1,6 +1,87 @@
 (ns sparkplug.function
-  "This namespace generates function classes for interop with Spark.")
+  "This namespace generates function classes for various kinds of interop with
+  Spark and Scala. This namespace **must** be AOT compiled before using Spark."
+  (:import
+    (java.lang.reflect
+      Field
+      Modifier)
+    java.util.HashSet
+    sparkplug.function.SerializableFn))
 
+
+;; ## Namespace Discovery
+
+(defn- access-field
+  "Attempt to get a field on the given object by making sure it is accessible.
+  Returns the field value on success, or nil on failure."
+  [^Field field obj]
+  (let [accessible? (.isAccessible field)]
+    (try
+      (when-not accessible?
+        (.setAccessible field true))
+      (.get field obj)
+      (catch IllegalAccessException ex
+        ;; TODO: warn?
+        nil)
+      (finally
+        ;; TODO: is this a good idea?
+        #_
+        (when-not accessible?
+          (try
+            (.setAccessible field false)
+            (catch Exception ex
+              ;; ignored
+              nil)))))))
+
+
+(defn- walk-object-vars
+  "Walk the given object to find namespaces referenced by vars. Adds discovered
+  reference symbols to `references` and tracks values in `visited`."
+  [^HashSet references ^HashSet visited obj]
+  (when-not (or (nil? obj)
+                ;; Simple types that can't have namespace references.
+                (boolean? obj)
+                (string? obj)
+                (number? obj)
+                (keyword? obj)
+                (symbol? obj)
+                (instance? clojure.lang.Ref obj)
+                ;; Nothing to do if we've already visited this object.
+                (.contains visited obj))
+    (.add visited obj)
+    (if (var? obj)
+      ;; Vars directly represent a namespace dependency.
+      (let [ns-sym (ns-name (:ns (meta obj)))]
+        (.add references ns-sym))
+      ;; Otherwise, traverse the object.
+      (do
+        ;; For maps and records, traverse over their contents in addition to
+        ;; their fields.
+        (when (map? obj)
+          (doseq [entry obj]
+            (walk-object-vars references visited entry)))
+        ;; Traverse the fields of the value for more references.
+        (doseq [^Field field (.getDeclaredFields (class obj))]
+          ;; Only traverse static fields for maps.
+          (when (or (not (map? obj)) (Modifier/isStatic (.getModifiers field)))
+            (let [value (access-field field obj)]
+              (when (or (ifn? value) (map? value))
+                (walk-object-vars references visited value)))))))))
+
+
+(defn namespace-references
+  "Walk the given function-like object to find all namespaces referenced by
+  closed-over vars. Returns a set of referenced namespace symbols."
+  [obj]
+  (let [references (HashSet.)
+        visited (HashSet.)]
+    (walk-object-vars references visited obj)
+    (disj (set references)
+          'clojure.core)))
+
+
+
+;; ## Function Wrappers
 
 (defmacro ^:private gen-function
   "Generate a new constructor for functions of the `fn-name` class that extends
@@ -11,7 +92,8 @@
     `(defn ~(vary-meta constructor assoc :tag class-sym)
        ~(str "Construct a new serializable " fn-name " function wrapping `f`.")
        [~'f]
-       (new ~class-sym ~'f))))
+       (let [references# (namespace-references ~'f)]
+         (new ~class-sym ~'f (mapv str references#))))))
 
 
 (gen-function Fn1 fn1)

--- a/sparkplug-core/src/clojure/sparkplug/function.clj
+++ b/sparkplug-core/src/clojure/sparkplug/function.clj
@@ -77,12 +77,11 @@
   [obj]
   (let [;; Attempt to derive the needed Clojure namespace
         ;; from the function's class name.
-        obj-ns (some->
-                 (.. obj getClass getName)
-                 (Compiler/demunge)
-                 (str/split #"/")
-                 (first)
-                 (symbol))
+        obj-ns (-> (.. obj getClass getName)
+                   (Compiler/demunge)
+                   (str/split #"/")
+                   (first)
+                   (symbol))
         references (HashSet. [obj-ns])
         visited (HashSet.)]
     (walk-object-vars references visited obj)

--- a/sparkplug-core/src/clojure/sparkplug/function.clj
+++ b/sparkplug-core/src/clojure/sparkplug/function.clj
@@ -24,16 +24,7 @@
       (.get field obj)
       (catch IllegalAccessException ex
         ;; TODO: warn?
-        nil)
-      (finally
-        ;; TODO: is this a good idea?
-        #_
-        (when-not accessible?
-          (try
-            (.setAccessible field false)
-            (catch Exception ex
-              ;; ignored
-              nil)))))))
+        nil))))
 
 
 (defn- walk-object-vars

--- a/sparkplug-core/src/clojure/sparkplug/function.clj
+++ b/sparkplug-core/src/clojure/sparkplug/function.clj
@@ -1,14 +1,14 @@
 (ns sparkplug.function
   "This namespace generates function classes for various kinds of interop with
   Spark and Scala."
+  (:require
+    [clojure.string :as str])
   (:import
     (java.lang.reflect
       Field
       Modifier)
     java.util.HashSet
-    sparkplug.function.SerializableFn)
-  (:require
-    [clojure.string :as str]))
+    sparkplug.function.SerializableFn))
 
 
 ;; ## Namespace Discovery

--- a/sparkplug-core/src/clojure/sparkplug/function.clj
+++ b/sparkplug-core/src/clojure/sparkplug/function.clj
@@ -6,7 +6,9 @@
       Field
       Modifier)
     java.util.HashSet
-    sparkplug.function.SerializableFn))
+    sparkplug.function.SerializableFn)
+  (:require
+    [clojure.string :as str]))
 
 
 ;; ## Namespace Discovery
@@ -73,12 +75,19 @@
   "Walk the given function-like object to find all namespaces referenced by
   closed-over vars. Returns a set of referenced namespace symbols."
   [obj]
-  (let [references (HashSet.)
+  (let [;; Attempt to derive the needed Clojure namespace
+        ;; from the function's class name.
+        obj-ns (some->
+                 (.. obj getClass getName)
+                 (Compiler/demunge)
+                 (str/split #"/")
+                 (first)
+                 (symbol))
+        references (HashSet. [obj-ns])
         visited (HashSet.)]
     (walk-object-vars references visited obj)
     (disj (set references)
           'clojure.core)))
-
 
 
 ;; ## Function Wrappers

--- a/sparkplug-core/src/clojure/sparkplug/kryo.clj
+++ b/sparkplug-core/src/clojure/sparkplug/kryo.clj
@@ -339,7 +339,6 @@
       (configure!))))
 
 
-
 ;; ## Serialization Logic
 
 ;; For types that are already registered with efficient serializers, see:

--- a/sparkplug-core/src/java/sparkplug/function/ComparatorFn.java
+++ b/sparkplug-core/src/java/sparkplug/function/ComparatorFn.java
@@ -3,6 +3,7 @@ package sparkplug.function;
 
 import clojure.lang.IFn;
 
+import java.util.Collection;
 import java.util.Comparator;
 
 
@@ -11,8 +12,8 @@ import java.util.Comparator;
  */
 public class ComparatorFn extends SerializableFn implements Comparator<Object> {
 
-    public ComparatorFn(IFn f) {
-        super(f);
+    public ComparatorFn(IFn f, Collection<String> namespaces) {
+        super(f, namespaces);
     }
 
 

--- a/sparkplug-core/src/java/sparkplug/function/FlatMapFn1.java
+++ b/sparkplug-core/src/java/sparkplug/function/FlatMapFn1.java
@@ -14,8 +14,8 @@ import org.apache.spark.api.java.function.FlatMapFunction;
  */
 public class FlatMapFn1 extends SerializableFn implements FlatMapFunction {
 
-    public FlatMapFn1(IFn f) {
-        super(f);
+    public FlatMapFn1(IFn f, Collection<String> namespaces) {
+        super(f, namespaces);
     }
 
 

--- a/sparkplug-core/src/java/sparkplug/function/FlatMapFn2.java
+++ b/sparkplug-core/src/java/sparkplug/function/FlatMapFn2.java
@@ -14,8 +14,8 @@ import org.apache.spark.api.java.function.FlatMapFunction2;
  */
 public class FlatMapFn2 extends SerializableFn implements FlatMapFunction2 {
 
-    public FlatMapFn2(IFn f) {
-        super(f);
+    public FlatMapFn2(IFn f, Collection<String> namespaces) {
+        super(f, namespaces);
     }
 
 

--- a/sparkplug-core/src/java/sparkplug/function/Fn1.java
+++ b/sparkplug-core/src/java/sparkplug/function/Fn1.java
@@ -3,6 +3,8 @@ package sparkplug.function;
 
 import clojure.lang.IFn;
 
+import java.util.Collection;
+
 import org.apache.spark.api.java.function.Function;
 
 
@@ -11,8 +13,8 @@ import org.apache.spark.api.java.function.Function;
  */
 public class Fn1 extends SerializableFn implements Function {
 
-    public Fn1(IFn f) {
-        super(f);
+    public Fn1(IFn f, Collection<String> namespaces) {
+        super(f, namespaces);
     }
 
 

--- a/sparkplug-core/src/java/sparkplug/function/Fn2.java
+++ b/sparkplug-core/src/java/sparkplug/function/Fn2.java
@@ -3,6 +3,8 @@ package sparkplug.function;
 
 import clojure.lang.IFn;
 
+import java.util.Collection;
+
 import org.apache.spark.api.java.function.Function2;
 
 
@@ -11,8 +13,8 @@ import org.apache.spark.api.java.function.Function2;
  */
 public class Fn2 extends SerializableFn implements Function2 {
 
-    public Fn2(IFn f) {
-        super(f);
+    public Fn2(IFn f, Collection<String> namespaces) {
+        super(f, namespaces);
     }
 
 

--- a/sparkplug-core/src/java/sparkplug/function/Fn3.java
+++ b/sparkplug-core/src/java/sparkplug/function/Fn3.java
@@ -3,6 +3,8 @@ package sparkplug.function;
 
 import clojure.lang.IFn;
 
+import java.util.Collection;
+
 import org.apache.spark.api.java.function.Function3;
 
 
@@ -11,8 +13,8 @@ import org.apache.spark.api.java.function.Function3;
  */
 public class Fn3 extends SerializableFn implements Function3 {
 
-    public Fn3(IFn f) {
-        super(f);
+    public Fn3(IFn f, Collection<String> namespaces) {
+        super(f, namespaces);
     }
 
 

--- a/sparkplug-core/src/java/sparkplug/function/PairFlatMapFn.java
+++ b/sparkplug-core/src/java/sparkplug/function/PairFlatMapFn.java
@@ -17,8 +17,8 @@ import scala.Tuple2;
  */
 public class PairFlatMapFn extends SerializableFn implements PairFlatMapFunction {
 
-    public PairFlatMapFn(IFn f) {
-        super(f);
+    public PairFlatMapFn(IFn f, Collection<String> namespaces) {
+        super(f, namespaces);
     }
 
 

--- a/sparkplug-core/src/java/sparkplug/function/PairFn.java
+++ b/sparkplug-core/src/java/sparkplug/function/PairFn.java
@@ -5,6 +5,8 @@ import clojure.lang.IFn;
 import clojure.lang.IMapEntry;
 import clojure.lang.IPersistentVector;
 
+import java.util.Collection;
+
 import org.apache.spark.api.java.function.PairFunction;
 
 import scala.Tuple2;
@@ -16,8 +18,8 @@ import scala.Tuple2;
  */
 public class PairFn extends SerializableFn implements PairFunction {
 
-    public PairFn(IFn f) {
-        super(f);
+    public PairFn(IFn f, Collection<String> namespaces) {
+        super(f, namespaces);
     }
 
 

--- a/sparkplug-core/src/java/sparkplug/function/SerializableFn.java
+++ b/sparkplug-core/src/java/sparkplug/function/SerializableFn.java
@@ -69,7 +69,8 @@ public abstract class SerializableFn implements Serializable {
     private void writeObject(ObjectOutputStream out) throws IOException {
         try {
             logger.trace("Serializing " + f);
-            // Write the function class name.
+            // Write the function class name
+            // This is only used for debugging
             out.writeObject(f.getClass().getName());
             // Write out the referenced namespaces.
             out.writeInt(namespaces.size());

--- a/sparkplug-core/src/java/sparkplug/function/SerializableFn.java
+++ b/sparkplug-core/src/java/sparkplug/function/SerializableFn.java
@@ -54,11 +54,9 @@ public abstract class SerializableFn implements Serializable {
      */
     protected SerializableFn(IFn fn, Collection<String> namespaces) {
         this.f = fn;
-        this.namespaces = new ArrayList<String>(namespaces);
-        // Attempt to derive the needed Clojure namespace from the function's class name.
-        String fnNamespace = Compiler.demunge(fn.getClass().getName()).split("/")[0];
-        this.namespaces.add(fnNamespace);
-        Collections.sort(this.namespaces);
+        List<String> namespaceColl = new ArrayList<String>(namespaces);
+        Collections.sort(namespaceColl);
+        this.namespaces = Collections.unmodifiableList(namespaceColl);
     }
 
 

--- a/sparkplug-core/src/java/sparkplug/function/SerializableFn.java
+++ b/sparkplug-core/src/java/sparkplug/function/SerializableFn.java
@@ -9,7 +9,6 @@ import clojure.lang.Var;
 
 import java.io.IOException;
 import java.io.InvalidObjectException;
-
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
@@ -41,10 +40,6 @@ public abstract class SerializableFn implements Serializable {
 
     /**
      * Default empty constructor.
-     *
-     * TODO is this accurate?
-     * Inheriting classes must also have an empty constructor to be properly
-     * serializable.
      */
     private SerializableFn() {
     }

--- a/sparkplug-core/src/java/sparkplug/function/SerializableFn.java
+++ b/sparkplug-core/src/java/sparkplug/function/SerializableFn.java
@@ -5,45 +5,48 @@ import clojure.lang.Compiler;
 import clojure.lang.IFn;
 import clojure.lang.RT;
 import clojure.lang.Symbol;
+import clojure.lang.Var;
 
 import java.io.IOException;
 import java.io.InvalidObjectException;
+
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * Base class for function classes built for interop with Spark and Scala.
+ *
+ * This class is designed to be serialized across computation boundaries in a
+ * manner compatible with Spark and Kryo, while ensuring that required code is
+ * loaded upon deserialization.
  */
 public abstract class SerializableFn implements Serializable {
 
+    private static final Logger logger = LoggerFactory.getLogger(SerializableFn.class);
+    private static final Var require = RT.var("clojure.core", "require");
+
     protected IFn f;
+    protected List<String> namespaces;
 
 
     /**
      * Default empty constructor.
+     *
+     * TODO is this accurate?
+     * Inheriting classes must also have an empty constructor to be properly
+     * serializable.
      */
     private SerializableFn() {
-    }
-
-
-    private void writeObject(ObjectOutputStream out) throws IOException {
-        // Attempt to derive the needed Clojure namespace from the function's class name.
-        String namespace = Compiler.demunge(this.f.getClass().getName()).split("/")[0];
-        out.writeObject(namespace);
-        out.writeObject(this.f);
-    }
-
-
-    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-        String namespace = (String)in.readObject();
-        Symbol namespaceSym = Symbol.intern(namespace);
-        // TODO: Try optimizing by doing an unsynchronized resolve first.
-        synchronized (RT.REQUIRE_LOCK) {
-            RT.var("clojure.core", "require").invoke(namespaceSym);
-        }
-        this.f = (IFn)in.readObject();
     }
 
 
@@ -52,9 +55,96 @@ public abstract class SerializableFn implements Serializable {
      * set of required namespaces.
      *
      * @param fn Clojure function to wrap
+     * @param namespaces collection of namespaces required
      */
-    protected SerializableFn(IFn fn) {
+    protected SerializableFn(IFn fn, Collection<String> namespaces) {
         this.f = fn;
+        this.namespaces = new ArrayList<String>(namespaces);
+        // Attempt to derive the needed Clojure namespace from the function's class name.
+        String fnNamespace = Compiler.demunge(fn.getClass().getName()).split("/")[0];
+        this.namespaces.add(fnNamespace);
+        Collections.sort(this.namespaces);
+    }
+
+
+    /**
+     * Serialize the function to the provided output stream.
+     * An unspoken part of the `Serializable` interface.
+     *
+     * @param out stream to write the function to
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        try {
+            logger.trace("Serializing " + f);
+            // Write the function class name.
+            out.writeObject(f.getClass().getName());
+            // Write out the referenced namespaces.
+            out.writeInt(namespaces.size());
+            for (String ns : namespaces) {
+                out.writeObject(ns);
+            }
+            // Write out the function itself.
+            out.writeObject(f);
+        } catch (IOException ex) {
+            logger.error("Error serializing function " + f, ex);
+            throw ex;
+        } catch (RuntimeException ex){
+            logger.error("Error serializing function " + f, ex);
+            throw ex;
+        }
+    }
+
+
+    /**
+     * Deserialize a function from the provided input stream.
+     * An unspoken part of the `Serializable` interface.
+     *
+     * @param in stream to read the function from
+     */
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        String className = "";
+        try {
+            // Read the function class name.
+            className = (String)in.readObject();
+            logger.trace("Deserializing " + className);
+            // Read the referenced namespaces and load them.
+            int nsCount = in.readInt();
+            this.namespaces = new ArrayList<String>(nsCount);
+            for (int i = 0; i < nsCount; i++) {
+                String ns = (String)in.readObject();
+                namespaces.add(ns);
+                requireNamespace(ns);
+            }
+            // Read the function itself.
+            this.f = (IFn)in.readObject();
+        } catch (IOException ex) {
+            logger.error("IO error deserializing function " + className, ex);
+            throw ex;
+        } catch (ClassNotFoundException ex) {
+            logger.error("Class error deserializing function " + className, ex);
+            throw ex;
+        } catch (RuntimeException ex) {
+            logger.error("Error deserializing function " + className, ex);
+            throw ex;
+        }
+    }
+
+
+    /**
+     * Load the namespace specified by the given symbol.
+     *
+     * @param namespace string designating the namespace to load
+     */
+    private static void requireNamespace(String namespace) {
+        try {
+            logger.trace("(require " + namespace + ")");
+            synchronized (RT.REQUIRE_LOCK) {
+                Symbol sym = Symbol.intern(namespace);
+                require.invoke(sym);
+            }
+        } catch (Exception ex) {
+            logger.warn("Error loading namespace " + namespace, ex);
+        }
     }
 
 }

--- a/sparkplug-core/src/java/sparkplug/function/VoidFn.java
+++ b/sparkplug-core/src/java/sparkplug/function/VoidFn.java
@@ -3,6 +3,8 @@ package sparkplug.function;
 
 import clojure.lang.IFn;
 
+import java.util.Collection;
+
 import org.apache.spark.api.java.function.VoidFunction;
 
 
@@ -11,8 +13,8 @@ import org.apache.spark.api.java.function.VoidFunction;
  */
 public class VoidFn extends SerializableFn implements VoidFunction {
 
-    public VoidFn(IFn f) {
-        super(f);
+    public VoidFn(IFn f, Collection<String> namespaces) {
+        super(f, namespaces);
     }
 
 

--- a/sparkplug-ml/project.clj
+++ b/sparkplug-ml/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/sparkplug-ml "0.1.1-SNAPSHOT"
+(defproject amperity/sparkplug-ml "0.1.2-SNAPSHOT"
   :description "Clojure API for Apache Spark Machine Learning"
   :url "https://github.com/amperity/sparkplug"
   :scm {:dir ".."}

--- a/sparkplug-repl/project.clj
+++ b/sparkplug-repl/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/sparkplug-repl "0.1.1-SNAPSHOT"
+(defproject amperity/sparkplug-repl "0.1.2-SNAPSHOT"
   :description "Clojure REPL for Spark exploration"
   :url "https://github.com/amperity/sparkplug"
   :scm {:dir ".."}

--- a/sparkplug-sql/project.clj
+++ b/sparkplug-sql/project.clj
@@ -1,4 +1,4 @@
-(defproject amperity/sparkplug-sql "0.1.1-SNAPSHOT"
+(defproject amperity/sparkplug-sql "0.1.2-SNAPSHOT"
   :description "Clojure API for Apache Spark SQL"
   :url "https://github.com/amperity/sparkplug"
   :scm {:dir ".."}


### PR DESCRIPTION
Mostly just a revert of https://github.com/amperity/sparkplug/commit/6f7ed70b312d9d4e94aaa404f713b7ebcadd490a, it turns out we... did sort of need that. 

This seems to fix a few issues with higher order function serialization: `partial` and `comp` in particular, where looking at the namespace of the function directly gives the wrong namespace to require for serialization/deserialization. 

Includes a revbump to `0.1.2-SNAPSHOT`.