### PR TITLE
Fix warnings when using keywords and sets as functions

### DIFF
--- a/sparkplug-core/src/clojure/sparkplug/function.clj
+++ b/sparkplug-core/src/clojure/sparkplug/function.clj
@@ -73,7 +73,12 @@
                    (str/split #"/")
                    (first)
                    (symbol))
-        references (doto (HashSet.) (.add obj-ns))
+        ;; When using a piece of data as a function, such as a keyword or set,
+        ;; obj-ns will actually be a class name like `clojure.lang.Keyword`.
+        ;; Avoid marking class names as namespaces to be required
+        references (if (class? (resolve obj-ns))
+                     (HashSet.)
+                     (doto (HashSet.) (.add obj-ns)))
         visited (HashSet.)]
     (walk-object-vars references visited obj)
     (disj (set references) 'clojure.core)))

--- a/sparkplug-core/src/clojure/sparkplug/function.clj
+++ b/sparkplug-core/src/clojure/sparkplug/function.clj
@@ -73,13 +73,13 @@
                    (str/split #"/")
                    (first)
                    (symbol))
-        ;; When using a piece of data as a function, such as a keyword or set,
-        ;; obj-ns will actually be a class name like `clojure.lang.Keyword`.
-        ;; Avoid marking class names as namespaces to be required
-        references (if (class? (resolve obj-ns))
-                     (HashSet.)
-                     (doto (HashSet.) (.add obj-ns)))
+        references (HashSet.)
         visited (HashSet.)]
+    ;; When using a piece of data as a function, such as a keyword or set,
+    ;; obj-ns will actually be a class name like `clojure.lang.Keyword`.
+    ;; Avoid marking class names as namespaces to be required.
+    (when-not (class? (resolve obj-ns))
+      (.add references obj-ns))
     (walk-object-vars references visited obj)
     (disj (set references) 'clojure.core)))
 


### PR DESCRIPTION
Seen a few times that doing something like
```clojure
(->> (rdd/parallelize spark-context [{:foo 1} {:foo 2}])
  	 (spark/map :foo)
	 (spark/collect))
```
results in log messages like:

> 19/12/16 04:20:01 WARN function.SerializableFn: Error loading namespace clojure.lang.Keyword
java.io.FileNotFoundException: Could not locate clojure/lang/Keyword__init.class, clojure/lang/Keyword.clj or clojure/lang/Keyword.cljc on classpath.

I think this can be solved with a small patch to check if the symbol resolves to a class name (as opposed to a namespace), and avoid marking it to be required in that case.