### PR TITLE
Grab-bag of small enhancements

### DIFF
--- a/sparkplug-core/dev/user.clj
+++ b/sparkplug-core/dev/user.clj
@@ -16,6 +16,12 @@
     com.esotericsoftware.kryo.Kryo))
 
 
+(def local-conf
+  (-> (conf/spark-conf)
+      (conf/master "local[*]")
+      (conf/app-name "user")))
+
+
 (def spark-context nil)
 
 

--- a/sparkplug-core/src/clojure/sparkplug/core.clj
+++ b/sparkplug-core/src/clojure/sparkplug/core.clj
@@ -483,11 +483,23 @@
   function, 2-arg combiner function, and a neutral zero value. Allows an
   aggregated value type that is different than the input value type, while
   avoiding unnecessary allocations. The number of reduce tasks is configurable
-  through an optional second argument."
+  by optionally passing a number of partitions or a partitioner."
   ([aggregator combiner zero ^JavaPairRDD rdd]
    (.aggregateByKey rdd zero (f/fn2 aggregator) (f/fn2 combiner)))
-  ([aggregator combiner zero ^Integer num-partitions ^JavaPairRDD rdd]
-   (.aggregateByKey rdd zero (f/fn2 aggregator) (f/fn2 combiner) num-partitions)))
+  ([aggregator combiner zero partitioner-or-num-partitions ^JavaPairRDD rdd]
+   (if (instance? Partitioner partitioner-or-num-partitions)
+     (.aggregateByKey
+       rdd
+       zero
+       ^Partitioner partitioner-or-num-partitions
+       (f/fn2 aggregator)
+       (f/fn2 combiner))
+     (.aggregateByKey
+       rdd
+       zero
+       (int partitioner-or-num-partitions)
+       (f/fn2 aggregator)
+       (f/fn2 combiner)))))
 
 
 (defn group-by

--- a/sparkplug-core/src/clojure/sparkplug/core.clj
+++ b/sparkplug-core/src/clojure/sparkplug/core.clj
@@ -477,6 +477,19 @@
 
 ;; ## Pair RDD Aggregation
 
+(defn aggregate-by-key
+  "When called on an RDD of (K, V) pairs, returns an RDD of (K, U) pairs where
+  the values for each key are aggregated using the given 2-arg aggregator
+  function, 2-arg combiner function, and a neutral zero value. Allows an
+  aggregated value type that is different than the input value type, while
+  avoiding unnecessary allocations. The number of reduce tasks is configurable
+  through an optional second argument."
+  ([aggregator combiner zero ^JavaPairRDD rdd]
+   (.aggregateByKey rdd zero (f/fn2 aggregator) (f/fn2 combiner)))
+  ([aggregator combiner zero ^Integer num-partitions ^JavaPairRDD rdd]
+   (.aggregateByKey rdd zero (f/fn2 aggregator) (f/fn2 combiner) num-partitions)))
+
+
 (defn group-by
   "Group the elements of `rdd` using a key function `f`. Returns a pair RDD
   with each generated key and all matching elements as a value sequence."

--- a/sparkplug-core/src/clojure/sparkplug/rdd.clj
+++ b/sparkplug-core/src/clojure/sparkplug/rdd.clj
@@ -56,16 +56,10 @@
   (first (remove internal-call? (.getStackTrace (Exception.)))))
 
 
-(defn- demunge
-  "Demunge a class name emitted by the Clojure compiler."
-  [^String classname]
-  (Compiler/demunge classname))
-
-
 (defn ^:no-doc fn-name
   "Return the (unmangled) name of the given Clojure function."
   [f]
-  (demunge (.getName (class f))))
+  (Compiler/demunge (.getName (class f))))
 
 
 (defn- callsite-name
@@ -76,7 +70,7 @@
         filename (.getFileName callsite)
         classname (.getClassName callsite)
         line-number (.getLineNumber callsite)]
-    (format "%s %s:%d" (demunge classname) filename line-number)))
+    (format "%s %s:%d" (Compiler/demunge classname) filename line-number)))
 
 
 (defn ^:no-doc set-callsite-name

--- a/sparkplug-core/src/clojure/sparkplug/scala.clj
+++ b/sparkplug-core/src/clojure/sparkplug/scala.clj
@@ -1,5 +1,6 @@
 (ns sparkplug.scala
   "Commonly used utilities for interop with Scala objects."
+  (:refer-clojure :exclude [first second])
   (:require
     [clojure.walk :as walk])
   (:import
@@ -151,7 +152,7 @@
     ;; Try to generically coerce a vector result.
     (vector? entry)
     (if (= 2 (count entry))
-      (Tuple2. (first entry) (second entry))
+      (Tuple2. (clojure.core/first entry) (clojure.core/second entry))
       (throw (IllegalArgumentException.
                (str "Cannot coerce a vector with " (count entry)
                     " elements to a pair value"))))
@@ -161,3 +162,15 @@
     (throw (IllegalArgumentException.
              (str "Cannot coerce unknown type " (.getName (class entry))
                   " to a pair value")))))
+
+
+(defn first
+  "Get the first element of a Scala pair."
+  [^Tuple2 t]
+  (._1 t))
+
+
+(defn second
+  "Get the second element of a Scala pair."
+  [^Tuple2 t]
+  (._2 t))

--- a/sparkplug-core/test/sparkplug/core_test.clj
+++ b/sparkplug-core/test/sparkplug/core_test.clj
@@ -1,0 +1,43 @@
+(ns sparkplug.core-test
+  (:require
+    [clojure.test :refer [deftest is testing use-fixtures]]
+    [sparkplug.config :as conf]
+    [sparkplug.context :as context]
+    [sparkplug.core :as spark]
+    [sparkplug.rdd :as rdd]))
+
+
+(def ^:dynamic *sc*
+  nil)
+
+
+(def local-conf
+  (-> (conf/spark-conf)
+      (conf/master "local[*]")
+      (conf/app-name "user")))
+
+
+(defn spark-context-fixture
+  [f]
+  (context/with-context [sc local-conf]
+    (binding [*sc* sc]
+      (f))))
+
+
+(use-fixtures :once spark-context-fixture)
+
+
+(deftest core-transforms
+  (testing "aggregate-by-key"
+    (is (= [[1 (reduce + (range 10))]]
+           (->> (rdd/parallelize-pairs *sc* (map vector (repeat 10 1) (range 10)))
+                (spark/aggregate-by-key + + 0)
+                (spark/into []))))
+    (is (= [[1 (reduce + (range 10))]]
+           (->> (rdd/parallelize-pairs *sc* (map vector (repeat 10 1) (range 10)))
+                (spark/aggregate-by-key + + 0 2)
+                (spark/into []))))
+    (is (= [[1 (reduce + (range 10))]]
+           (->> (rdd/parallelize-pairs *sc* (map vector (repeat 10 1) (range 10)))
+                (spark/aggregate-by-key + + 0 (rdd/hash-partitioner 2))
+                (spark/into []))))))


### PR DESCRIPTION
* Add a `local-conf` helper to the user ns
* Add `scala/first` and `scala/second` which are useful in practice for pair RDDs
* Add `aggregate-by-key`

* RDD naming was a little off, replaced the logic with Clojure's own demunge. 

	Before:

	```clojure
	user=> (ctx/with-context [sc local-conf] (->> (rdd/parallelize sc (range 20)) (rdd/filter even?) (rdd/name)))
	"#<JavaRDD: user/eval12882 form-init5973586216259780457.clj:1  [clojure.core/even-QMARK-]>"
	```

	After:
	
	```clojure
	user=> (ctx/with-context [sc local-conf] (->> (rdd/parallelize sc (range 20)) (spark/filter even?) (rdd/name)))
	"#<JavaRDD: user/eval12156 form-init9185969785814975164.clj:1  [clojure.core/even?]>"
	```