### PR TITLE
A few improvements

### DIFF
--- a/sparkplug-core/src/clojure/sparkplug/core.clj
+++ b/sparkplug-core/src/clojure/sparkplug/core.clj
@@ -463,14 +463,14 @@
   ^JavaPairRDD
   ([^JavaPairRDD rdd1 ^JavaPairRDD rdd2]
    (rdd/set-callsite-name
-     (.rightOuterJoin rdd1 rdd2)))
+     (.fullOuterJoin rdd1 rdd2)))
   ([^JavaPairRDD rdd1 ^JavaPairRDD rdd2 partitions]
    (if (instance? Partitioner partitions)
      (rdd/set-callsite-name
-       (.rightOuterJoin rdd1 rdd2 ^Partitioner partitions)
+       (.fullOuterJoin rdd1 rdd2 ^Partitioner partitions)
        (class partitions))
      (rdd/set-callsite-name
-       (.rightOuterJoin rdd1 rdd2 (int partitions))
+       (.fullOuterJoin rdd1 rdd2 (int partitions))
        (int partitions)))))
 
 

--- a/sparkplug-core/src/clojure/sparkplug/rdd.clj
+++ b/sparkplug-core/src/clojure/sparkplug/rdd.clj
@@ -8,6 +8,7 @@
   (:refer-clojure :exclude [empty name partition-by])
   (:require
     [clojure.string :as str]
+    [sparkplug.function :as f]
     [sparkplug.scala :as scala])
   (:import
     clojure.lang.Compiler
@@ -19,7 +20,8 @@
       JavaRDD
       JavaRDDLike
       JavaSparkContext
-      StorageLevels)))
+      StorageLevels)
+    sparkplug.partition.FnHashPartitioner))
 
 
 ;; ## Naming Functions
@@ -188,11 +190,7 @@
    (HashPartitioner. n))
   ^HashPartitioner
   ([key-fn n]
-   (proxy [HashPartitioner] [n]
-     (getPartition
-       [k]
-       (let [k' (key-fn k)]
-         (mod (hash k') n))))))
+   (FnHashPartitioner. (int n) (f/fn1 key-fn))))
 
 
 (defn partitions

--- a/sparkplug-core/src/clojure/sparkplug/rdd.clj
+++ b/sparkplug-core/src/clojure/sparkplug/rdd.clj
@@ -185,11 +185,11 @@
   "Construct a partitioner which will hash keys to distribute them uniformly
   over `n` buckets. Optionally accepts a `key-fn` which will be called on each
   key before hashing it."
-  ^Partitioner
-  ([n]
-   (HashPartitioner. n))
-  ^Partitioner
-  ([key-fn n]
+  (^Partitioner
+   [n]
+   (HashPartitioner. (int n)))
+  (^Partitioner
+   [key-fn n]
    (FnHashPartitioner. (int n) (f/fn1 key-fn))))
 
 

--- a/sparkplug-core/src/clojure/sparkplug/rdd.clj
+++ b/sparkplug-core/src/clojure/sparkplug/rdd.clj
@@ -185,10 +185,10 @@
   "Construct a partitioner which will hash keys to distribute them uniformly
   over `n` buckets. Optionally accepts a `key-fn` which will be called on each
   key before hashing it."
-  ^HashPartitioner
+  ^Partitioner
   ([n]
    (HashPartitioner. n))
-  ^HashPartitioner
+  ^Partitioner
   ([key-fn n]
    (FnHashPartitioner. (int n) (f/fn1 key-fn))))
 

--- a/sparkplug-core/src/clojure/sparkplug/rdd.clj
+++ b/sparkplug-core/src/clojure/sparkplug/rdd.clj
@@ -237,6 +237,18 @@
     (int n)))
 
 
+(defn repartition-and-sort-within-partitions
+  "Repartition the RDD according to the given partitioner and, within each
+  resulting partition, sort records by their keys. This is more efficient than
+  calling repartition and then sorting within each partition because it can
+  push the sorting down into the shuffle machinery."
+  ^JavaPairRDD
+  ([^Partitioner partitioner ^JavaPairRDD pair-rdd]
+   (.repartitionAndSortWithinPartitions pair-rdd partitioner))
+  ([^Partitioner partitioner ^java.util.Comparator comparator ^JavaPairRDD pair-rdd]
+   (.repartitionAndSortWithinPartitions pair-rdd partitioner comparator)))
+
+
 ;; Type hints are omitted because `coalesce` is not included in JavaRDDLike.
 (defn coalesce
   "Decrease the number of partitions in `rdd` to `n`. Useful for running

--- a/sparkplug-core/src/java/sparkplug/partition/FnHashPartitioner.java
+++ b/sparkplug-core/src/java/sparkplug/partition/FnHashPartitioner.java
@@ -1,0 +1,51 @@
+package sparkplug.partition;
+
+import org.apache.spark.Partitioner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import sparkplug.function.Fn1;
+
+
+/**
+ * A Partitioner Similar to Spark's HashPartitioner, which also accepts a key
+ * function to translate an Object into a hashable key, and uses Clojure's
+ * hash function instead of Object.hashCode().
+ */
+public class FnHashPartitioner extends Partitioner {
+
+    private static final Logger logger = LoggerFactory.getLogger(FnHashPartitioner.class);
+
+    private final int numPartitions;
+    private final Fn1 keyFn;
+
+    public FnHashPartitioner(int numPartitions, Fn1 keyFn) {
+        if (numPartitions <= 0) {
+            throw new IllegalArgumentException("Number of partitions must be positive, got " + numPartitions);
+        }
+        if (keyFn == null) {
+            throw new IllegalArgumentException("Key function must not be null");
+        }
+        this.numPartitions = numPartitions;
+        this.keyFn = keyFn;
+    }
+
+    @Override
+    public int numPartitions() {
+        return this.numPartitions;
+    }
+
+    @Override
+    public int getPartition(Object key) {
+        Object transformedKey = null;
+        try {
+            transformedKey = this.keyFn.call(key);
+        } catch (Exception e) {
+            logger.error("Key function threw an exception, so this key will be hashed as if it were null."
+                         + " This is likely to cause skewed partitioning.", e);
+        }
+
+        return Math.floorMod(clojure.lang.Util.hasheq(transformedKey), this.numPartitions);
+    }
+
+}

--- a/sparkplug-core/src/java/sparkplug/partition/FnHashPartitioner.java
+++ b/sparkplug-core/src/java/sparkplug/partition/FnHashPartitioner.java
@@ -1,5 +1,6 @@
 package sparkplug.partition;
 
+import static clojure.lang.Util.hasheq;
 import org.apache.spark.Partitioner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +46,7 @@ public class FnHashPartitioner extends Partitioner {
                          + " This is likely to cause skewed partitioning.", e);
         }
 
-        return Math.floorMod(clojure.lang.Util.hasheq(transformedKey), this.numPartitions);
+        return Math.floorMod(hasheq(transformedKey), this.numPartitions);
     }
 
 }


### PR DESCRIPTION
A few improvements:

1. Previously `(rdd/hash-partitioner key-fn n)` used `proxy`, which wouldn't work because it's not serializable. Instead, re-implement it using a new partitioner class. Issue #14 

2. Correct `full-outer-join` to use `.fullOuterJoin` (copy and paste mistake). Issue #13 

3. Add `repartition-and-sort-within-partitions`.