### PR TITLE
Add sortBy wrapper

### DIFF
--- a/sparkplug-core/src/clojure/sparkplug/core.clj
+++ b/sparkplug-core/src/clojure/sparkplug/core.clj
@@ -6,7 +6,7 @@
   thread-last macro (`->>`), making it simple to migrate existing Clojure
   code."
   (:refer-clojure :exclude [count distinct filter first group-by into keys map
-                            mapcat max min reduce take vals])
+                            mapcat max min reduce sort-by take vals])
   (:require
     [clojure.core :as c]
     [clojure.tools.logging :as log]
@@ -143,6 +143,27 @@
      (boolean replacement?)
      (long seed))))
 
+
+(defn sort-by
+  "Reorder the elements of `rdd` so that they are sorted according to the given
+  key function. The result may be ordered ascending or descending, depending on
+  `ascending?`."
+  (^JavaRDD
+   [f ^JavaRDD rdd]
+   (sort-by f true rdd))
+  (^JavaRDD
+   [f ascending? ^JavaRDD rdd]
+   (sort-by f ascending? (.getNumPartitions rdd) rdd))
+  (^JavaRDD
+   [f ascending? num-partitions ^JavaRDD rdd]
+   (rdd/set-callsite-name
+     (.sortBy rdd
+              (f/fn1 f)
+              (boolean ascending?)
+              num-partitions)
+     (rdd/fn-name f)
+     (boolean ascending?)
+     (int num-partitions))))
 
 
 ;; ## Pair RDD Transformations

--- a/sparkplug-core/test/sparkplug/core_test.clj
+++ b/sparkplug-core/test/sparkplug/core_test.clj
@@ -40,4 +40,13 @@
     (is (= [[1 (reduce + (range 10))]]
            (->> (rdd/parallelize-pairs *sc* (map vector (repeat 10 1) (range 10)))
                 (spark/aggregate-by-key + + 0 (rdd/hash-partitioner 2))
+                (spark/into [])))))
+
+  (testing "sort-by"
+    (is (= (vec (reverse (range 10)))
+           (->> (rdd/parallelize *sc* (shuffle (range 10)))
+                (spark/sort-by -)
+                (spark/into []))
+           (->> (rdd/parallelize *sc* (shuffle (range 10)))
+                (spark/sort-by identity false)
                 (spark/into []))))))


### PR DESCRIPTION
I added a wrapper for `sortBy`. Weirdly, JavaRDD doesn't seem to implement multiple arities for `sortBy` so I did the delegation through the clojure wrapper (as opposed to sort-by-key, which maps to each arity directly) https://github.com/amperity/sparkplug/blob/0f6124d7fc8f0e3f8869f8dce66b26370af34942/sparkplug-core/src/clojure/sparkplug/core.clj#L586-L616