### PR TITLE
Improve namespace reference walking

### DIFF
--- a/sparkplug-core/src/clojure/sparkplug/function.clj
+++ b/sparkplug-core/src/clojure/sparkplug/function.clj
@@ -77,9 +77,8 @@
       ;; For collection-like objects, (e.g. vectors, maps, records, Java collections),
       ;; just traverse the objects they contain.
       (seqable? obj)
-      (do
-        (doseq [entry obj]
-          (walk-object-refs references visited entry)))
+      (doseq [entry obj]
+        (walk-object-refs references visited entry))
 
       ;; Otherwise, reflectively traverse the fields of the object for more references.
       :else

--- a/sparkplug-core/src/clojure/sparkplug/function.clj
+++ b/sparkplug-core/src/clojure/sparkplug/function.clj
@@ -27,7 +27,18 @@
         nil))))
 
 
-(defn- walk-object-vars
+(defn- fn-namespace
+  "Given a function object, derive the name of the namespace where it was
+  defined."
+  [obj]
+  (-> (.getName (class obj))
+      (Compiler/demunge)
+      (str/split #"/")
+      (first)
+      (symbol)))
+
+
+(defn- walk-object-refs
   "Walk the given object to find namespaces referenced by vars. Adds discovered
   reference symbols to `references` and tracks values in `visited`."
   [^HashSet references ^HashSet visited obj]
@@ -42,45 +53,49 @@
                 ;; Nothing to do if we've already visited this object.
                 (.contains visited obj))
     (.add visited obj)
-    (if (var? obj)
+    (cond
       ;; Vars directly represent a namespace dependency.
+      (var? obj)
       (let [ns-sym (ns-name (:ns (meta obj)))]
         (.add references ns-sym))
-      ;; Otherwise, traverse the object.
-      (do
-        ;; For maps and records, traverse over their contents in addition to
-        ;; their fields.
-        (when (map? obj)
-          (doseq [entry obj]
-            (walk-object-vars references visited entry)))
-        ;; Traverse the fields of the value for more references.
-        (doseq [^Field field (.getDeclaredFields (class obj))]
-          ;; Only traverse static fields for maps.
-          (when (or (not (map? obj)) (Modifier/isStatic (.getModifiers field)))
+
+      ;; Clojure functions:
+      ;; Try to derive the namespace that defined the function.
+      ;; Functions also have Var references as static fields,
+      ;; and have closed-over objects as non-static fields.
+      (fn? obj)
+      (let [ns-sym (fn-namespace obj)]
+        ;; When using a piece of data as a function, such as a keyword or set,
+        ;; this will actually be a class name like `clojure.lang.Keyword`.
+        ;; Avoid marking class names as namespaces to be required.
+        (when-not (class? (resolve ns-sym))
+          (.add references ns-sym)
+          (doseq [^Field field (.getDeclaredFields (class obj))]
             (let [value (access-field field obj)]
-              (when (or (ifn? value) (map? value))
-                (walk-object-vars references visited value)))))))))
+              (walk-object-refs references visited value)))))
+
+      ;; For collection-like objects, (e.g. vectors, maps, records, Java collections),
+      ;; just traverse the objects they contain.
+      (seqable? obj)
+      (do
+        (doseq [entry obj]
+          (walk-object-refs references visited entry)))
+
+      ;; Otherwise, reflectively traverse the fields of the object for more references.
+      :else
+      (doseq [^Field field (.getDeclaredFields (class obj))]
+        (when-not (Modifier/isStatic (.getModifiers field))
+          (let [value (access-field field obj)]
+            (walk-object-refs references visited value)))))))
 
 
 (defn namespace-references
   "Walk the given function-like object to find all namespaces referenced by
   closed-over vars. Returns a set of referenced namespace symbols."
   [^Object obj]
-  (let [;; Attempt to derive the needed Clojure namespace
-        ;; from the function's class name.
-        obj-ns (-> (.. obj getClass getName)
-                   (Compiler/demunge)
-                   (str/split #"/")
-                   (first)
-                   (symbol))
-        references (HashSet.)
+  (let [references (HashSet.)
         visited (HashSet.)]
-    ;; When using a piece of data as a function, such as a keyword or set,
-    ;; obj-ns will actually be a class name like `clojure.lang.Keyword`.
-    ;; Avoid marking class names as namespaces to be required.
-    (when-not (class? (resolve obj-ns))
-      (.add references obj-ns))
-    (walk-object-vars references visited obj)
+    (walk-object-refs references visited obj)
     (disj (set references) 'clojure.core)))
 
 

--- a/sparkplug-core/test/sparkplug/function_test.clj
+++ b/sparkplug-core/test/sparkplug/function_test.clj
@@ -1,0 +1,81 @@
+(ns sparkplug.function-test
+  (:require
+    [clojure.test :refer [are deftest is]]
+    [sparkplug.function :as f]))
+
+
+(def this-ns (ns-name *ns*))
+
+
+(defprotocol TestProto
+
+  (proto-method [this]))
+
+
+(defrecord TestRecord
+  [example-fn]
+
+  TestProto
+
+  (proto-method [this] (example-fn)))
+
+
+(deftest resolve-namespace-references
+  (are [expected-references obj] (= expected-references (f/namespace-references obj))
+
+    ;; Simple data
+    #{} nil
+    #{} :keyword
+    #{} 5
+    #{} true
+    #{} "str"
+    #{} 'sym
+
+    ;; Functions
+    #{this-ns}
+    (fn [])
+
+    #{this-ns 'sparkplug.function}
+    (fn []
+      (f/namespace-references (fn [])))
+
+    #{this-ns 'sparkplug.function}
+    (fn []
+      (let [x (f/namespace-references (fn []))]
+        (x)))
+
+    #{this-ns}
+    [(fn [])]
+
+    #{this-ns}
+    (list (fn []))
+
+    #{this-ns}
+    (doto (java.util.ArrayList.)
+      (.add (fn [])))
+
+    #{this-ns}
+    (doto (java.util.HashMap.)
+      (.put "key" (fn [])))
+
+    #{this-ns}
+    {:key (fn [])}
+
+    #{this-ns}
+    {:key {:nested (fn [])}}
+
+    #{this-ns}
+    {:key {:nested [(fn [])]}}
+
+    ;; Record fields.
+    #{this-ns 'sparkplug.function}
+    (->TestRecord
+      (fn []
+        (f/namespace-references nil)))
+
+    ;; Function that closes over an object invoking a protocol method.
+    #{this-ns 'sparkplug.function}
+    (let [inst (->TestRecord
+                 (fn []
+                   (f/namespace-references nil)))]
+      (fn [] (proto-method inst)))))


### PR DESCRIPTION
Resolves #16 by walking the `seq` of objects that are `seqable`. Improves the walking logic for Clojure functions. Adds several tests for `namespace-references`, including some that previously failed.