### PR TITLE
Address illegal reflection errors in Java 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,11 @@ version: 2.1
 executors:
   clojure:
     docker:
-      - image: circleci/clojure:openjdk-8-lein-2.9.1
+      - image: circleci/clojure:openjdk-8-lein-2.9.4
     working_directory: ~/repo
   clojure-java-11:
     docker:
-      - image: circleci/clojure:openjdk-11-lein-2.9.1
+      - image: circleci/clojure:openjdk-11-lein-2.9.4
     working_directory: ~/repo
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ executors:
     working_directory: ~/repo
 
 
-
 # Job definitions
 jobs:
   style:
@@ -81,7 +80,7 @@ jobs:
           command: lein monolith each install
       - run:
           name: Generate coverage
-          command: lein monolith with-all cloverage --codecov
+          command: lein monolith each :in sparkplug-core with-profile +spark-2.4 cloverage --codecov
       - save_cache:
           key: v1-coverage-{{ checksum "project.clj" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,11 @@ executors:
     docker:
       - image: circleci/clojure:openjdk-8-lein-2.9.1
     working_directory: ~/repo
+  clojure-java-11:
+    docker:
+      - image: circleci/clojure:openjdk-11-lein-2.9.1
+    working_directory: ~/repo
+
 
 
 # Job definitions
@@ -41,6 +46,24 @@ jobs:
           command: lein monolith each do clean, check, install
       - save_cache:
           key: v1-test-{{ checksum "project.clj" }}
+          paths:
+            - ~/.m2
+
+  test-spark-3-java-11:
+    executor: clojure-java-11
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-test-spark-3-java-11-{{ checksum "project.clj" }}
+            - v1-test-spark-3-java-11-
+      - run:
+          name: Test projects
+          command: |
+            lein -version
+            lein monolith each with-profile +spark-3.0 do clean, check, install
+      - save_cache:
+          key: v1-test-spark-3-java-11-{{ checksum "project.clj" }}
           paths:
             - ~/.m2
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,11 @@ version: 2.1
 executors:
   clojure:
     docker:
-      - image: circleci/clojure:openjdk-8-lein-2.9.4
+      - image: circleci/clojure:openjdk-8-lein-2.9.5
     working_directory: ~/repo
   clojure-java-11:
     docker:
-      - image: circleci/clojure:openjdk-11-lein-2.9.4
+      - image: circleci/clojure:openjdk-11-lein-2.9.5
     working_directory: ~/repo
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,7 @@ workflows:
     jobs:
       - style
       - test
+      - test-spark-3-java-11
       - coverage:
           requires:
             - test

--- a/project.clj
+++ b/project.clj
@@ -9,8 +9,8 @@
   :deploy-repositories {"releases" {:url "https://repo.clojars.org"}}
 
   :plugins
-  [[lein-cloverage "1.1.1"]
-   [lein-monolith "1.2.2"]]
+  [[lein-cloverage "1.2.2"]
+   [lein-monolith "1.6.1"]]
 
   :dependencies
   [[org.clojure/clojure "1.10.1"]

--- a/sparkplug-core/src/clojure/sparkplug/function.clj
+++ b/sparkplug-core/src/clojure/sparkplug/function.clj
@@ -24,7 +24,7 @@
         (.setAccessible field true))
       (.get field obj)
       (catch Exception e
-        (log/trace "Failed to access field %s: %s" field (class e))
+        (log/tracef "Failed to access field %s: %s" field (class e))
         nil))))
 
 

--- a/sparkplug-core/src/clojure/sparkplug/function.clj
+++ b/sparkplug-core/src/clojure/sparkplug/function.clj
@@ -2,7 +2,8 @@
   "This namespace generates function classes for various kinds of interop with
   Spark and Scala."
   (:require
-    [clojure.string :as str])
+    [clojure.string :as str]
+    [clojure.tools.logging :as log])
   (:import
     (java.lang.reflect
       Field
@@ -22,8 +23,8 @@
       (when-not accessible?
         (.setAccessible field true))
       (.get field obj)
-      (catch IllegalAccessException ex
-        ;; TODO: warn?
+      (catch Exception e
+        (log/trace "Failed to access field %s: %s" field (class e))
         nil))))
 
 

--- a/sparkplug-repl/project.clj
+++ b/sparkplug-repl/project.clj
@@ -25,11 +25,13 @@
      :init-ns sparkplug.repl.work}}
 
    :spark-2.4
+   ^{:pom-scope :provided}
    {:dependencies
     [[org.apache.spark/spark-core_2.12 "2.4.4"]
      [org.apache.spark/spark-sql_2.12 "2.4.4"]]}
 
    :spark-3.0
+   ^{:pom-scope :provided}
    {:dependencies
     [[org.apache.spark/spark-core_2.12 "3.0.1"]
      [org.apache.spark/spark-sql_2.12 "3.0.1"]]}

--- a/sparkplug-repl/project.clj
+++ b/sparkplug-repl/project.clj
@@ -10,18 +10,29 @@
   :dependencies
   [[org.clojure/clojure "1.10.1"]
    [amperity/sparkplug-core "0.1.6-SNAPSHOT"]
-   [org.apache.spark/spark-core_2.12 "2.4.4"]
-   [org.apache.spark/spark-sql_2.12 "2.4.4"]
    [mvxcvi/whidbey "2.1.1"]
    [nrepl "0.6.0"]]
 
   :main sparkplug.repl.main
 
   :profiles
-  {:repl
+  {:default
+   [:base :system :user :provided :spark-2.4 :dev]
+
+   :repl
    {:repl-options
     {:custom-init (whidbey.repl/update-print-fn!)
      :init-ns sparkplug.repl.work}}
+
+   :spark-2.4
+   {:dependencies
+    [[org.apache.spark/spark-core_2.12 "2.4.4"]
+     [org.apache.spark/spark-sql_2.12 "2.4.4"]]}
+
+   :spark-3.0
+   {:dependencies
+    [[org.apache.spark/spark-core_2.12 "3.0.1"]
+     [org.apache.spark/spark-sql_2.12 "3.0.1"]]}
 
    :uberjar
    {:target-path "target/uberjar"


### PR DESCRIPTION
`walk-object-refs` will fail to access fields on Java 11, example error:

```
java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.lang.String java.lang.module.ModuleDescriptor.name accessible: module java.base does not "opens java.lang.module" to unnamed module @5d30303
```

This is because it's currently catching a `java.lang.IllegalAccessException`, which is Java 8's behavior. However, Java 11 will throw a `java.lang.reflect.InaccessibleObjectException` in this scenario. The former class is new in Java 11, and plain `Exception` is their lowest common ancestor.

Also adding CI steps for Spark 3 / Java 11