### PR TITLE
Update `union` implementation for Spark 2/3 cross-compatibility

### DIFF
--- a/sparkplug-core/src/java/sparkplug/core/UnionHelper.java
+++ b/sparkplug-core/src/java/sparkplug/core/UnionHelper.java
@@ -1,0 +1,33 @@
+package sparkplug.core;
+
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+
+/**
+ * This is a simple wrapper to call the `union` method on `JavaSparkContext`.
+ *
+ * It is written in Java because:
+ *
+ * The non-varargs version of `union` was removed in Spark 3, leaving the varargs version as the
+ * only one that is compatible with both Spark 2 and Spark 3. See:
+ * <https://issues.apache.org/jira/browse/SPARK-25737>
+ *
+ * Unfortunately, Clojure is unable to call the varargs version, due to a compiler bug. Doing so
+ * will fail with errors such as:
+ *
+ * IllegalArgumentException: Can't call public method of non-public class: public final
+ * org.apache.spark.api.java.JavaPairRDD
+ * org.apache.spark.api.java.JavaSparkContextVarargsWorkaround.union(org.apache.spark.api.java.JavaPairRDD[])
+ *
+ * See: <https://clojure.atlassian.net/browse/CLJ-1243>
+ */
+public class UnionHelper {
+  public static JavaRDD unionJavaRDDs(JavaSparkContext jsc, JavaRDD[] rdds) {
+    return jsc.union(rdds);
+  }
+
+  public static JavaPairRDD unionJavaPairRDDs(JavaSparkContext jsc, JavaPairRDD[] rdds) {
+    return jsc.union(rdds);
+  }
+}

--- a/sparkplug-core/test/sparkplug/core_test.clj
+++ b/sparkplug-core/test/sparkplug/core_test.clj
@@ -50,4 +50,32 @@
                 (spark/into []))
            (->> (rdd/parallelize *sc* (shuffle (range 10)))
                 (spark/sort-by identity false)
-                (spark/into []))))))
+                (spark/into [])))))
+
+  (testing "union"
+    (is (= #{:a :b :c :d}
+           (spark/into
+             #{}
+             (spark/union
+               (rdd/parallelize *sc* [:a :b])
+               (rdd/parallelize *sc* [:c :d])))))
+    (is (= #{:a :b :c :d :e :f}
+           (spark/into
+             #{}
+             (spark/union
+               (rdd/parallelize *sc* [:a :b])
+               (rdd/parallelize *sc* [:c :d])
+               (rdd/parallelize *sc* [:e :f])))))
+    (is (= #{[:a :b] [:c :d]}
+           (spark/into
+             #{}
+             (spark/union
+               (rdd/parallelize-pairs *sc* [[:a :b]])
+               (rdd/parallelize-pairs *sc* [[:c :d]])))))
+    (is (= #{[:a :b] [:c :d] [:e :f]}
+           (spark/into
+             #{}
+             (spark/union
+               (rdd/parallelize-pairs *sc* [[:a :b]])
+               (rdd/parallelize-pairs *sc* [[:c :d]])
+               (rdd/parallelize-pairs *sc* [[:e :f]])))))))

--- a/sparkplug-core/test/sparkplug/core_test.clj
+++ b/sparkplug-core/test/sparkplug/core_test.clj
@@ -53,6 +53,8 @@
                 (spark/into [])))))
 
   (testing "union"
+    (is (= #{:a :b}
+           (spark/into #{} (spark/union (rdd/parallelize *sc* [:a :b])))))
     (is (= #{:a :b :c :d}
            (spark/into
              #{}
@@ -66,6 +68,8 @@
                (rdd/parallelize *sc* [:a :b])
                (rdd/parallelize *sc* [:c :d])
                (rdd/parallelize *sc* [:e :f])))))
+    (is (= #{[:a :b]}
+           (spark/into #{} (spark/union (rdd/parallelize-pairs *sc* [[:a :b]])))))
     (is (= #{[:a :b] [:c :d]}
            (spark/into
              #{}


### PR DESCRIPTION
Spark 3 removed the signatures of `JavaSparkContext#union` that sparkplug was using, leaving only the varargs signatures: https://issues.apache.org/jira/browse/SPARK-25737

This modifies the implementation of `sparkplug.core/union` to use the varargs signature so that it works with both Spark 2 and Spark 3.