### PR TITLE
Fix serialized record closures

### DIFF
--- a/sparkplug-core/test/sparkplug/function_test.clj
+++ b/sparkplug-core/test/sparkplug/function_test.clj
@@ -9,7 +9,9 @@
 
 (defprotocol TestProto
 
-  (proto-method [this]))
+  (proto-method [this])
+
+  (get-closure [this]))
 
 
 (defrecord TestRecord
@@ -17,7 +19,16 @@
 
   TestProto
 
-  (proto-method [this] (example-fn)))
+  (proto-method
+    [this]
+    (example-fn))
+
+
+  (get-closure
+    [this]
+    (fn inside-fn
+      []
+      nil)))
 
 
 (deftest resolve-namespace-references
@@ -78,4 +89,9 @@
     (let [inst (->TestRecord
                  (fn []
                    (f/namespace-references nil)))]
-      (fn [] (proto-method inst)))))
+      (fn [] (proto-method inst)))
+
+    ;; Function closure defined inside a record class.
+    #{this-ns}
+    (let [x (->TestRecord nil)]
+      (get-closure x))))


### PR DESCRIPTION
This bug surfaces when Sparkplug tries to serialize functions which are closures defined inside of a `defrecord` form. The resulting serialized value includes a reference to the record name itself as a "namespace" to require before the function is loaded, but this fails on the executor because records aren't namespaces. This wasn't being caught by the existing `(class? (resolve x))` check, because in this case the record was in a namespace that had hyphens in it, and class names must use the underscore version (thanks Java).

To fix this, we need to make the logic here a bit more robust - now it correctly detects class names by swapping out the underscores, and if the _parent_ of that class is itself a namespace, use that instead. The existing behavior should continue ignoring values like `clojure.lang.Keyword`.