### PR TITLE
Update tested Spark versions to 3.1 and 3.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,21 +46,21 @@ jobs:
           paths:
             - ~/.m2
 
-  test-spark-3-2-java-11:
+  test-spark-3-5-java-11:
     executor: clojure-java-11
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v1-test-spark-3.2-java-11-{{ checksum "project.clj" }}
-            - v1-test-spark-3.2-java-11-
+            - v1-test-spark-3.5-java-11-{{ checksum "project.clj" }}
+            - v1-test-spark-3.5-java-11-
       - run:
           name: Test projects
           command: |
             lein -version
-            lein monolith each with-profile -spark-3.1,+spark-3.2 do clean, check, install, test
+            lein monolith each with-profile -spark-3.1,+spark-3.5 do clean, check, install, test
       - save_cache:
-          key: v1-test-spark-3.2-java-11-{{ checksum "project.clj" }}
+          key: v1-test-spark-3.5-java-11-{{ checksum "project.clj" }}
           paths:
             - ~/.m2
 
@@ -98,7 +98,7 @@ workflows:
     jobs:
       - style
       - test-spark-3-1-java-11
-      - test-spark-3-2-java-11
+      - test-spark-3-5-java-11
       - coverage:
           requires:
             - test-spark-3-1-java-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Changed
-- Sparkplug is now tested with Java 11 + Spark 3.1.3, and Java 11 + Spark 3.2.1.
+- Sparkplug is now tested with Java 11 + Spark 3.1.3, and Java 11 + Spark 3.5.1.
   Java 8 test coverage was dropped.
 - Bump Clojure to 1.11.1.
 

--- a/sparkplug-core/project.clj
+++ b/sparkplug-core/project.clj
@@ -37,7 +37,7 @@
    {:dependencies
     [[org.apache.spark/spark-core_2.12 "3.1.3"]]}
 
-   :spark-3.2
+   :spark-3.5
    ^{:pom-scope :provided}
    {:dependencies
-    [[org.apache.spark/spark-core_2.12 "3.2.1"]]}})
+    [[org.apache.spark/spark-core_2.12 "3.5.1"]]}})

--- a/sparkplug-repl/project.clj
+++ b/sparkplug-repl/project.clj
@@ -30,11 +30,11 @@
     [[org.apache.spark/spark-core_2.12 "3.1.3"]
      [org.apache.spark/spark-sql_2.12 "3.1.3"]]}
 
-   :spark-3.2
+   :spark-3.5
    ^{:pom-scope :provided}
    {:dependencies
-    [[org.apache.spark/spark-core_2.12 "3.2.1"]
-     [org.apache.spark/spark-sql_2.12 "3.2.1"]]}
+    [[org.apache.spark/spark-core_2.12 "3.5.1"]
+     [org.apache.spark/spark-sql_2.12 "3.5.1"]]}
 
    :uberjar
    {:target-path "target/uberjar"


### PR DESCRIPTION
Currently, sparkplug does not ship with any Spark dependencies. Consumers include sparkplug as a bit of "Clojure glue", and must also include their desired version of Spark dependencies in order to actually use sparkplug.

Sparkplug is currently cross-tested against Spark 3.1 and Spark 3.2 dependencies. This PR updates sparkplug to be cross-tested against Spark 3.1 and Spark 3.5.