### PR TITLE
Fix boolean closure values when deserializing functions

### DIFF
--- a/sparkplug-core/dev/sparkplug/bool_repro.clj
+++ b/sparkplug-core/dev/sparkplug/bool_repro.clj
@@ -1,0 +1,8 @@
+(ns sparkplug.bool-repro
+  (:require
+    [sparkplug.function :as f]))
+
+
+(defn make-test-fn
+  [b]
+  (f/fn1 (fn inner [x] (when b x))))

--- a/sparkplug-core/dev/sparkplug/bool_repro.clj
+++ b/sparkplug-core/dev/sparkplug/bool_repro.clj
@@ -1,8 +1,0 @@
-(ns sparkplug.bool-repro
-  (:require
-    [sparkplug.function :as f]))
-
-
-(defn make-test-fn
-  [b]
-  (f/fn1 (fn inner [x] (when b x))))

--- a/sparkplug-core/dev/user.clj
+++ b/sparkplug-core/dev/user.clj
@@ -5,6 +5,7 @@
     [clojure.stacktrace :refer [print-cause-trace]]
     [clojure.string :as str]
     [clojure.tools.namespace.repl :refer [refresh]]
+    [sparkplug.bool-repro :as bool]
     [sparkplug.config :as conf]
     [sparkplug.context :as ctx]
     [sparkplug.core :as spark]
@@ -60,8 +61,51 @@
                           (+ % 256)
                           %))]
             (if (or (Character/isLetterOrDigit c)
-                    (Character/isWhitespace c))
+                    (and (Character/isWhitespace c)
+                         (not= \newline c)))
               c
               \.)))
-    (str/join)
+    (partition-all 32)
+    (map str/join)
+    (str/join "\n")
     (println)))
+
+
+;; Boolean Shenanigans Reproduction
+
+(defn access-field
+  [value field]
+  (#'f/access-field field value))
+
+
+(def serializable-fn-field
+  (nth (.getDeclaredFields sparkplug.function.SerializableFn) 2))
+
+
+(def test-fn-inner-class
+  (class (access-field (bool/make-test-fn true) serializable-fn-field)))
+
+
+(def test-fn-boolean-field
+  (first (.getDeclaredFields test-fn-inner-class)))
+
+
+(defn get-inner-boolean
+  [sf]
+  (-> sf
+      (access-field serializable-fn-field)
+      (access-field test-fn-boolean-field)))
+
+
+(defn encode-fn
+  [sf]
+  (let [baos (java.io.ByteArrayOutputStream.)]
+    (with-open [out (java.io.ObjectOutputStream. baos)]
+      (.writeObject out sf))
+    (.toByteArray baos)))
+
+
+(defn decode-fn
+  [bs]
+  (with-open [in (java.io.ObjectInputStream. (java.io.ByteArrayInputStream. bs))]
+    (.readObject in)))

--- a/sparkplug-core/project.clj
+++ b/sparkplug-core/project.clj
@@ -26,6 +26,7 @@
 
    :repl
    {:source-paths ["dev"]
+    :aot [sparkplug.bool-repro]
     :dependencies
     [[org.clojure/tools.namespace "1.3.0"]]}
 

--- a/sparkplug-core/project.clj
+++ b/sparkplug-core/project.clj
@@ -17,12 +17,17 @@
 
   :profiles
   {:default
-   [:base :system :user :provided :spark-3.1 :dev]
+   [:base :system :user :provided :spark-3.5 :dev]
 
    :dev
-   {:jvm-opts ["-server" "-Xmx2g"]
-    :dependencies
-    [[org.clojure/test.check "1.1.1"]]}
+   {:dependencies
+    [[org.clojure/test.check "1.1.1"]
+     [org.slf4j/slf4j-api "2.0.7"]
+     [org.slf4j/slf4j-simple "2.0.7"]]
+    :jvm-opts ["-Xmx2g"
+               "-XX:-OmitStackTraceInFastThrow"
+               "-Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
+               "-Dorg.slf4j.simpleLogger.log.org.apache=warn"]}
 
    :repl
    {:source-paths ["dev"]
@@ -41,4 +46,9 @@
    :spark-3.5
    ^{:pom-scope :provided}
    {:dependencies
-    [[org.apache.spark/spark-core_2.12 "3.5.1"]]}})
+    [[org.apache.spark/spark-core_2.12 "3.5.1"
+      :exclusions [org.apache.logging.log4j/log4j-slf4j2-impl]]
+
+     ;; Conflict resolution
+     [com.fasterxml.jackson.core/jackson-core "2.15.2"]
+     [com.google.code.findbugs/jsr305 "3.0.2"]]}})

--- a/sparkplug-core/project.clj
+++ b/sparkplug-core/project.clj
@@ -31,12 +31,11 @@
 
    :repl
    {:source-paths ["dev"]
-    :aot [sparkplug.bool-repro]
     :dependencies
     [[org.clojure/tools.namespace "1.3.0"]]}
 
    :test
-   {:jvm-opts ["-XX:-OmitStackTraceInFastThrow"]}
+   {:aot [sparkplug.function.test-fns]}
 
    :spark-3.1
    ^{:pom-scope :provided}

--- a/sparkplug-core/test/sparkplug/function/test_fns.clj
+++ b/sparkplug-core/test/sparkplug/function/test_fns.clj
@@ -1,0 +1,10 @@
+(ns sparkplug.function.test-fns
+  "AOT-compiled test functions.")
+
+
+(defn bool-closure
+  [b]
+  (fn inner
+    [x]
+    (when b
+      x)))


### PR DESCRIPTION
A couple of intersecting issues cause incorrect behavior when a function which closes over a boolean value is serialized to execute on a Spark worker. We're relying on Java's default object serialization for the most part, since functions are custom classes with unique fields based on the code inside them. The closure values are represented as instance fields of type `Object`, so booleans get boxed into a `Boolean` value.

Booleans in Java have two canonical instances for the true and false boxed values, `Boolean/TRUE` and `Boolean/FALSE`, respectively; in Clojure, a "truthiness" evaluation only considers `nil` and `Boolean/FALSE` to be falsey values. Unfortunately, the language implementation of `java.lang.Boolean` doesn't customize the behavior of the `Serializable` interface, so when we deserialize the closed-over value we get back a _new_ `(Boolean. false)` instance, which Clojure treats as truthy. Thus the bug.

To fix this, we can do something _extremely gross_ but workable, which is to walk the deserialized function and update any closed-over `Boolean` values to map them back to the two canonical instances.

Fixes #27 